### PR TITLE
Allow shares to be created and combined as bytes rather than strings

### DIFF
--- a/sssa_test.go
+++ b/sssa_test.go
@@ -2,6 +2,7 @@ package sssa
 
 import (
 	"testing"
+	"bytes"
 )
 
 func TestCreateCombine(t *testing.T) {
@@ -25,6 +26,32 @@ func TestCreateCombine(t *testing.T) {
 			t.Fatal("Fatal: combining: ", err)
 		}
 		if combined != strings[i] {
+			t.Fatal("Fatal: combining returned invalid data")
+		}
+	}
+}
+
+func TestCreateCombineBytes(t *testing.T) {
+	// Short, medium, and long tests
+	testvals := [][]byte{
+		[]byte("N17FigASkL6p1EOgJhRaIquQLGvYV0"),
+		[]byte("0y10VAfmyH7GLQY6QccCSLKJi8iFgpcSBTLyYOGbiYPqOpStAf1OYuzEBzZR"),
+		[]byte("KjRHO1nHmIDidf6fKvsiXWcTqNYo2U9U8juO94EHXVqgearRISTQe0zAjkeUYYBvtcB8VWzZHYm6ktMlhOXXCfRFhbJzBUsXaHb5UDQAvs2GKy6yq0mnp8gCj98ksDlUultqygybYyHvjqR7D7EAWIKPKUVz4of8OzSjZlYg7YtCUMYhwQDryESiYabFID1PKBfKn5WSGgJBIsDw5g2HB2AqC1r3K8GboDN616Swo6qjvSFbseeETCYDB3ikS7uiK67ErIULNqVjf7IKoOaooEhQACmZ5HdWpr34tstg18rO"),
+	}
+
+	minimum := []int{4, 6, 20}
+	shares := []int{5, 100, 100}
+
+	for i := range testvals {
+		created, err := CreateFromBytes(minimum[i], shares[i], testvals[i])
+		if err != nil {
+			t.Fatal("Fatal: creating: ", err)
+		}
+		combined, err := CombineAsBytes(created)
+		if err != nil {
+			t.Fatal("Fatal: combining: ", err)
+		}
+		if !bytes.Equal(combined, testvals[i]) {
 			t.Fatal("Fatal: combining returned invalid data")
 		}
 	}


### PR DESCRIPTION
This functionality will allow a cli to share binary files without needless conversion to and from strings.